### PR TITLE
Fix the `SteeringMovement` crash and the `melee_attack()` rotation bug

### DIFF
--- a/src/hades/views/game.py
+++ b/src/hades/views/game.py
@@ -109,7 +109,6 @@ class Game(arcade.View):
 
         # Add all the indicator bars to the game
         indicator_bar_offset = 0
-        # TODO: Can we move indicator bar initialisation to HadesSprite?
         for component in constructor.components:
             if type(component) in INDICATOR_BAR_COMPONENTS and isinstance(
                 component,
@@ -368,8 +367,6 @@ class Game(arcade.View):
         )
         player_x, player_y = kinematic_component.get_position()
 
-        # TODO: This doesn't seem to be correct for the melee attack. Atan2 is returning
-        #  a mirrored result
         # Transform the mouse from window space to world space using the camera position
         # then set the player's rotation
         kinematic_component.set_rotation(

--- a/src/hades_extensions/src/game_objects/systems/movements.cpp
+++ b/src/hades_extensions/src/game_objects/systems/movements.cpp
@@ -97,7 +97,7 @@ void SteeringMovementSystem::update(const double /*delta_time*/) const {
        get_registry()->find_components<SteeringMovement, KinematicComponent>()) {
     // Unpack the components and check if the target game object exists
     const auto [steering_movement, kinematic_owner] = component_tuple;
-    if (steering_movement->target_id == -1) {
+    if (!get_registry()->has_component(steering_movement->target_id, typeid(KinematicComponent))) {
       continue;
     }
     const auto kinematic_target{get_registry()->get_component<KinematicComponent>(steering_movement->target_id)};

--- a/src/hades_extensions/tests/game_objects/systems/test_attacks.cpp
+++ b/src/hades_extensions/tests/game_objects/systems/test_attacks.cpp
@@ -48,7 +48,7 @@ class AttackSystemFixture : public testing::Test {
     const int game_object_id{registry.create_game_object(
         GameObjectType::Player, cpvzero,
         {std::make_shared<Attack>(enabled_attacks), std::make_shared<KinematicComponent>(std::vector<cpVect>{})})};
-    registry.get_component<KinematicComponent>(game_object_id)->rotation = std::numbers::pi;
+    registry.get_component<KinematicComponent>(game_object_id)->rotation = -std::numbers::pi / 2;
   }
 
   /// Get the attack system from the registry.
@@ -118,10 +118,10 @@ TEST_F(AttackSystemFixture, TestAttackSystemDoAttackRanged) {
   bool bullet_created{false};
   auto bullet_creation_observer{[&](const GameObjectID game_object_id) {
     const auto *bullet{*registry.get_component<KinematicComponent>(game_object_id)->body};
-    ASSERT_EQ(bullet->p.x, -32);
-    ASSERT_NEAR(bullet->p.y, 32, 1e-13);
-    ASSERT_EQ(bullet->v.x, -500);
-    ASSERT_NEAR(bullet->v.y, 0, 1e-13);
+    ASSERT_NEAR(bullet->p.x, 32, 1e-13);
+    ASSERT_NEAR(bullet->p.y, -32, 1e-13);
+    ASSERT_NEAR(bullet->v.x, 0, 1e-13);
+    ASSERT_NEAR(bullet->v.y, -500, 1e-13);
     bullet_created = true;
   }};
   registry.add_observer(EventType::BulletCreation, bullet_creation_observer);

--- a/src/hades_extensions/tests/game_objects/systems/test_movements.cpp
+++ b/src/hades_extensions/tests/game_objects/systems/test_movements.cpp
@@ -250,8 +250,8 @@ TEST_F(KeyboardMovementSystemFixture, TestKeyboardMovementSystemUpdateIncomplete
   ASSERT_EQ(registry.get_component<KinematicComponent>(0)->body->f, cpvzero);
 }
 
-/// Test that a game object is not updated if the target ID is not set
-TEST_F(SteeringMovementSystemFixture, TestSteeringMovementSystemUpdateNoTargetId) {
+/// Test that a game object is not updated if the target ID is invalid.
+TEST_F(SteeringMovementSystemFixture, TestSteeringMovementSystemUpdateInvalidTargetId) {
   create_steering_movement_component({});
   registry.get_component<SteeringMovement>(1)->target_id = -1;
   get_steering_movement_system()->update(0);


### PR DESCRIPTION
## Description of Changes

This PR fixes the crash when a player game object is deleted from the registry, but the event loop has not finished completing. It also fixes the rotation problem with `melee_attack()` so it can now be used correctly.

## Type of Changes

<!-- Select the type of changes that this pull request includes -->

|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug Fix          |
|       | :sparkles: New Feature |
|       | :hammer: Refactoring   |
|       | :memo: Miscellaneous   |

## Tasks

<!-- List the tasks needed for this pull request -->

- [x] Fix the `SteeringMovement` crash.
- [x] Fix the `melee_attack()` rotation bug.
