### PR TITLE
Introduce a `texture_cache` to avoid calling `load_texture()` too much

### DIFF
--- a/src/hades/constructors.py
+++ b/src/hades/constructors.py
@@ -48,9 +48,15 @@ from hades_extensions.game_objects.components import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from arcade import Texture
+
     from hades_extensions.game_objects import ComponentBase
 
-__all__ = ("GameObjectConstructor", "game_object_constructors")
+__all__ = ("GameObjectConstructor", "game_object_constructors", "texture_cache")
+
+
+# The cache for all Arcade textures
+texture_cache: dict[str, Texture] = {}
 
 
 @dataclass()
@@ -77,6 +83,7 @@ class GameObjectConstructor:
 
     def __post_init__(self: GameObjectConstructor) -> None:
         """Post-initialise the object."""
+        # Initialise the correct kinematic component if needed
         if self.kinematic:
             self.components.append(
                 KinematicComponent(
@@ -90,6 +97,11 @@ class GameObjectConstructor:
             )
         elif self.static:
             self.components.append(KinematicComponent(is_static=True))
+
+        # Load the texture(s) into their respective caches
+        for texture_path in self.texture_paths:
+            if texture_path not in texture_cache:
+                texture_cache[texture_path] = load_texture(texture_path)
 
 
 def wall_factory() -> GameObjectConstructor:

--- a/src/hades/sprite.py
+++ b/src/hades/sprite.py
@@ -9,11 +9,10 @@ from typing import TYPE_CHECKING
 from arcade import (
     BasicSprite,
     Texture,
-    load_texture,
 )
 
 # Custom
-from hades.constructors import game_object_constructors
+from hades.constructors import game_object_constructors, texture_cache
 from hades_extensions.game_objects import (
     SPRITE_SCALE,
     GameObjectType,
@@ -55,7 +54,7 @@ class HadesSprite(BasicSprite):
             constructor: The game object's constructor.
         """
         super().__init__(
-            load_texture(constructor.texture_paths[0]),
+            texture_cache[constructor.texture_paths[0]],
             SPRITE_SCALE,
             *grid_pos_to_pixel(position),
         )
@@ -166,7 +165,7 @@ class AnimatedSprite(HadesSprite):
         """
         super().__init__(registry, game_object_id, position, constructor)
         self.sprite_textures: list[tuple[Texture, Texture]] = [
-            (load_texture(texture), load_texture(texture).flip_left_right())
+            (texture_cache[texture], texture_cache[texture].flip_left_right())
             for texture in constructor.texture_paths
         ]
 

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -6,9 +6,19 @@ from __future__ import annotations
 import pytest
 
 # Custom
-from hades.constructors import GameObjectConstructor, game_object_constructors
+from hades.constructors import (
+    GameObjectConstructor,
+    game_object_constructors,
+    texture_cache,
+)
 from hades_extensions.game_objects import GameObjectType
 from hades_extensions.game_objects.components import KinematicComponent
+
+
+@pytest.fixture(autouse=True)
+def _clear_texture_cache() -> None:
+    """Clear the texture cache before each test."""
+    texture_cache.clear()
 
 
 @pytest.mark.parametrize(
@@ -51,3 +61,17 @@ def test_factory_functions(
     assert (
         KinematicComponent in [type(component) for component in constructor.components]
     ) == (constructor.static or constructor.kinematic)
+    for texture_path in constructor.texture_paths:
+        assert texture_cache[texture_path] is not None
+
+
+def test_nonexistent_texture_path() -> None:
+    """Test that a FileNotFoundError is raised when a texture path does not exist."""
+    with pytest.raises(expected_exception=FileNotFoundError, match="non_existent.png"):
+        GameObjectConstructor(
+            "Test",
+            "Test description",
+            GameObjectType.Player,
+            ["non_existent.png"],
+            kinematic=True,
+        )

--- a/tests/test_sprite.py
+++ b/tests/test_sprite.py
@@ -10,9 +10,10 @@ from unittest.mock import Mock
 
 # Pip
 import pytest
+from arcade import Texture
 
 # Custom
-from hades.constructors import GameObjectConstructor
+from hades.constructors import GameObjectConstructor, texture_cache
 from hades.sprite import AnimatedSprite, Bullet, HadesSprite
 from hades_extensions.game_objects import GameObjectType, Vec2d
 
@@ -42,6 +43,14 @@ def mock_constructor(request: pytest.FixtureRequest) -> Mock:
     mock_constructor.description = "Test description"
     mock_constructor.game_object_type = GameObjectType.Player
     mock_constructor.texture_paths = [f":resources:{param}" for param in request.param]
+    for mock_texture_path in mock_constructor.texture_paths:
+        mock_texture = Mock(spec=Texture)
+        mock_texture.size = (32, 32)
+        mock_texture.file_path = texture_path / mock_texture_path.replace(
+            ":resources:",
+            "",
+        )
+        texture_cache[mock_texture_path] = mock_texture
     return mock_constructor
 
 
@@ -191,11 +200,6 @@ def test_animated_sprite_init(
             [],
             Vec2d(10, 20),
             [IndexError, "list index out of range"],
-        ),
-        (
-            ["non_existent.png"],
-            Vec2d(5, 10),
-            [FileNotFoundError, "non_existent.png"],
         ),
         (
             ["floor.png"],


### PR DESCRIPTION
## Description of Changes

This PR introduces a `texture_cache` as `load_texture()` was being called for every sprite (and their flipped equivalent) leading to an exponential slowdown in initialising a game.

## Type of Changes

<!-- Select the type of changes that this pull request includes -->

|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug Fix          |
| ✓   | :sparkles: New Feature |
|       | :hammer: Refactoring   |
|       | :memo: Miscellaneous   |

## Tasks

<!-- List the tasks needed for this pull request -->

- [x] Introduce a `texture_cache` to fix the performance bottleneck of `_create_sprite()`.
- [x] Update the tests so that they pass with this new cache.
