### PR TITLE
Fix the CI errors with `lukka/get-cmake`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,15 +11,15 @@ updates:
       - "type: dependency"
       - "status: pending"
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
+      interval: "daily"
+  - package-ecosystem: "uv"
     directory: "/"
     groups:
-      pip-dependencies:
+      uv-dependencies:
         patterns:
           - "*"  # Update all dependencies
     labels:
       - "type: dependency"
       - "status: pending"
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -26,7 +26,7 @@ jobs:
           setup-python-dependencies: false
       - name: Set up CMake
         if: matrix.language == 'cpp'
-        uses: lukka/get-cmake@v4.02
+        uses: lukka/get-cmake@v4.0.2
       - name: Build CMake
         if: matrix.language == 'cpp'
         working-directory: ${{ github.workspace }}/src/hades_extensions

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
       - name: Set up CMake
-        uses: lukka/get-cmake@v4.02
+        uses: lukka/get-cmake@v4.0.2
       - name: Configure CMake
         working-directory: ${{ github.workspace }}/src/hades_extensions
         run: pip install conan && cmake --preset Debug

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1.13.0
       - name: Set up CMake
-        uses: lukka/get-cmake@v4.02
+        uses: lukka/get-cmake@v4.0.2
       - name: Install Mesa on Windows for headless Arcade
         if: matrix.os == 'windows-latest'
         uses: ssciwr/setup-mesa-dist-win@v2
@@ -54,7 +54,7 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1.13.0
       - name: Set up CMake
-        uses: lukka/get-cmake@v4.02
+        uses: lukka/get-cmake@v4.0.2
       - name: Build CMake and run CTest
         working-directory: ${{ github.workspace }}/src/hades_extensions
         run: |


### PR DESCRIPTION
This PR fixes the CI errors with `lukka/get-cmake` and switches to the uv package-ecosystem for Dependabot.

## Type of Changes

<!-- Select the type of changes that this pull request includes -->

|     | Type                   |
|-----|------------------------|
|       | :bug: Bug Fix          |
|       | :sparkles: New Feature |
|       | :hammer: Refactoring   |
| ✓   | :memo: Miscellaneous   |

## Tasks

<!-- List the tasks needed for this pull request -->

- [x] Fix the CI issues.
- [x] Switch to the uv package-ecosystem.